### PR TITLE
telephony: fix for duplicate apn option under Settings app

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -132,7 +132,9 @@
          are applied to. [CHAR LIMIT=40] -->
     <string name="labelCdmaMore_with_label">CDMA call settings (<xliff:g id="subscriptionlabel" example="Verizon">%s</xliff:g>)</string>
     <!-- Mobile network settings screen, setting option name -->
-    <string name="apn_settings">Access Point Names</string>
+    <string name="apn_settings">Access point names</string>
+    <!-- Mobile network settings screen, setting option description -->
+    <string name="apn_settings_summary">Change network APN details</string>
     <!-- Label for the "Network settings" screen in the Settings UI -->
     <string name="settings_label">Network settings</string>
 

--- a/res/xml/cdma_options.xml
+++ b/res/xml/cdma_options.xml
@@ -36,6 +36,7 @@
     <PreferenceScreen
         android:key="button_apn_key_cdma"
         android:title="@string/apn_settings"
+        android:summary="@string/apn_settings_summary"
         android:persistent="false">
 
         <!-- The launching Intent will be defined thru code as we need to pass some Extra -->

--- a/res/xml/gsm_umts_options.xml
+++ b/res/xml/gsm_umts_options.xml
@@ -20,6 +20,7 @@
     <PreferenceScreen
         android:key="button_apn_key"
         android:title="@string/apn_settings"
+        android:summary="@string/apn_settings_summary"
         android:persistent="false">
 
         <!-- The launching Intent will be defined thru code as we need to pass some Extra -->

--- a/src/com/android/phone/CdmaOptions.java
+++ b/src/com/android/phone/CdmaOptions.java
@@ -63,7 +63,6 @@ public class CdmaOptions {
 
     protected void create() {
         mPrefActivity.addPreferencesFromResource(R.xml.cdma_options);
-
         mButtonAPNExpand = (PreferenceScreen) mPrefScreen.findPreference(BUTTON_APN_EXPAND_KEY);
         boolean removedAPNExpand = false;
         PersistableBundle carrierConfig =
@@ -90,6 +89,7 @@ public class CdmaOptions {
                             return true;
                         }
             });
+            com.android.phone.MobileNetworkSettings.isAPNSettingAdded = true;
         }
 
         mButtonCdmaSystemSelect = (CdmaSystemSelectListPreference)mPrefScreen

--- a/src/com/android/phone/GsmUmtsOptions.java
+++ b/src/com/android/phone/GsmUmtsOptions.java
@@ -138,6 +138,12 @@ public class GsmUmtsOptions {
                             return true;
                         }
             });
+            com.android.phone.MobileNetworkSettings.isAPNSettingAdded = true;
+        }
+
+        if (mButtonAPNExpand != null && com.android.phone.MobileNetworkSettings
+                .isAPNSettingAdded) {
+            mPrefScreen.removePreference(mButtonAPNExpand);
         }
     }
 

--- a/src/com/android/phone/MobileNetworkSettings.java
+++ b/src/com/android/phone/MobileNetworkSettings.java
@@ -84,6 +84,8 @@ public class MobileNetworkSettings extends PreferenceActivity
     private static final boolean DBG = true;
     public static final int REQUEST_CODE_EXIT_ECM = 17;
 
+    protected static boolean isAPNSettingAdded = false;
+
     // Number of active Subscriptions to show tabs
     private static final int TAB_THRESHOLD = 2;
 


### PR DESCRIPTION
observations (usecase):
For dual sim mobile following files adding the APN settings option
- gsm_umts_options.xml
- cdma_options.xml

MobileNetworkSettings class using above two preferencescreens
and which is duplicating it.

PatchSet 2:

 - Added summary to align with other options under network screen
 - Corrected APN screen name case to align with Settings app design
 - Have fixed logic to remove APN duplicate to obey all conditions

Change-Id: I8491f61cc9d4f5010135b0c4e8b126d3f2ead6c9
Signed-off-by: Simao Gomes Viana <xdevs23@outlook.com>